### PR TITLE
Fix numbering of examples

### DIFF
--- a/tour/12_tour_of_scala_anonymous_functions_2.md
+++ b/tour/12_tour_of_scala_anonymous_functions_2.md
@@ -16,10 +16,10 @@ code:
   val add3:(Int,Int)=>Int = _ + _ //alternate way  
   val add4 = (_ + _):(Int,Int)=>Int //alternate way, rare   
       
-  println(add0(42,13))  
   println(add1(42,13))  
   println(add2(42,13))  
   println(add3(42,13))  
+  println(add4(42,13))  
   
 ---
 


### PR DESCRIPTION
The values were not consistent, so running the example would provide:

```
error L58:not found: value add0
```
